### PR TITLE
Fix Chrome rendering

### DIFF
--- a/src/metrics/helper.js
+++ b/src/metrics/helper.js
@@ -62,7 +62,9 @@ function exportAsHtml(markdownTemplate, jsonData, dotGraphs) {
         <script>
             let staticMetrics = ${JSON.stringify(data)};
 
-            window.postMessage({"command":"renderReport", value:staticMetrics}, '*')
+            window.addEventListener('load', function() {
+                window.postMessage({"command":"renderReport", value:staticMetrics}, '*')
+            });
         </script>`;
     
     return result.index.replace("<!--/*** %%static_metrics%% ***/-->", staticJsCss);


### PR DESCRIPTION
The report rendering is triggered by a window message, which happens immediately in the `<head>` section. Because the DOM is not fully loaded, the `div#preview` element is not yet loaded, resulting in `document.getElementById("preview")` returning `null`.

This change defers posting the message and triggering the report rendering until the document has been fully loaded, fixing the issue where the report was not rendering on Chrome.